### PR TITLE
Add the ability to set a top level class

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `viz` component takes a hash-map of the following:
 | :svg             | svg                |                                                 | yes       |
 | :main-container  | main-container     |                                                 | no        |
 | :pieces          | [ piece ]          |                                                 | no        |
+| :class           | string             |                                                 | no        |
 
 - an `:id` is required to differentiate between different rid3's
 - a `:ratom` can be a reagent atom, reagent cursor, or a re-frame subscription. This should be used to store all of the data relevant to your rid3.

--- a/src/main/rid3/viz.cljs
+++ b/src/main/rid3/viz.cljs
@@ -8,9 +8,10 @@
 
 (defn component-render [opts]
   (let [{:keys [id
-                ratom]} opts
+                ratom
+                class]} opts
         _trigger-update @ratom]
-    [:div {:id id}]))
+    [:div {:id id :class class}]))
 
 
 (defn component-did-mount [opts]


### PR DESCRIPTION
Add the ability to set class on highest-level `div` the whole component (and update the README accordingly). 

I was using this to build some custom, reusable charts, and I didn't have a way within rid3 to apply a class to all of my chart types.

In this PR I applied to the class to the `div` that wraps the whole component (same place the `id` is applied. I could easily imagine applying it further down the chain, if that makes more sense to you. 