### PR TITLE
Add a new macro for use in animating mouseover and other things

### DIFF
--- a/src/main/rid3/core.clj
+++ b/src/main/rid3/core.clj
@@ -10,3 +10,8 @@
                          forms)]
     `(-> ~node
          ~@forms-sanitized)))
+
+(defmacro rid3on-> [& forms]
+  `(this-is this#
+            (rid3-> (.select d3 this#)
+                    ~@forms)))

--- a/src/main/rid3/core.clj
+++ b/src/main/rid3/core.clj
@@ -15,3 +15,10 @@
   `(this-is this#
             (rid3-> (.select d3 this#)
                     ~@forms)))
+
+(defmacro rid3on->2 [node attr & forms]
+  `(.on ~node ~attr
+        (fn [d i]
+          (this-as this
+                   (rid3-> (.select d3 this)
+                           ~@forms)))))


### PR DESCRIPTION
## Goal

I was trying to add animations to my d3, using the this form found [on the bl.ocks.org](http://bl.ocks.org/WilliamQLiu/76ae20060e19bf42d774). 

abbreviated:
```cljs
svg.selectAll("circle")
     .data(dataset)
     .enter()
     .append("circle")
     .attr(circleAttrs)  // Get attributes from circleAttrs var
     .on("mouseover", handleMouseOver);

function handleMouseOver(d, i) {  // Add interactivity
    d3.select(this).attr({
        fill: "orange",
        r: radius * 2
    });
}
```

To do, I wrote the following cljs, which works fine.
```cljs
{ ...               
  :did-mount
    (fn [node ratom] 
                 (rid3-> node
                              (.on "mouseover"
                               (fn [d i]
                                 (this-as this    ;; *
                                       (rid3-> (.select d3 this)  ;; *
                                               .transition
                                               (.duration 500)
                                               {:y (+ (y-scale d) 100))}))))))}                                      
```

## PR in use
I was hoping to simplify this a bit with a macro, and after a few attempts I wrote the macro (seen in code) which can be used like. The lines marked `;; *` are the ones replaced by the macro

```cljs
{ ...               
  :did-mount
    (fn [node ratom] 
                 (rid3-> node
                              (.on "mouseover"
                               (fn [d i]
                                 (rid3on->
                                  .transition
                                  (.duration 500)
                                  {:y  (+ (y-scale d) 100)})))))}
```
 
## Discussion

1) This is my first attempt at writing a "real" macro, so any/all feedback is appreciated
2) This macro technically hides the `this` from the user, so if someone wanted that, they couldn't use the macro
3) I was hoping for the macro to cover more (ideally starting with the `.on` and going through the `(.select d3 this#)`. This would hid the `[d i]` parameters that a user probably wants. We could include these in the macro, but it feels weird to me to have your macro spit variables into the local state. maybe that's not weird?

## Tests

This should probably come with tests, but I wasn't sure how to run your current test suite -- let me know, and I'll gladly add some. 